### PR TITLE
Update SWIFT_SNAPSHOT to 2016-02-08

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER IBM Swift Engineering at IBM Cloud
 LABEL Description="Image to create a Linux environment with the latest Swift binaries."
 
 # Variables
-ENV SWIFT_SNAPSHOT swift-DEVELOPMENT-SNAPSHOT-2016-02-25-a
+ENV SWIFT_SNAPSHOT swift-DEVELOPMENT-SNAPSHOT-2016-02-08-a
 ENV UBUNTU_VERSION ubuntu15.10
 ENV UBUNTU_VERSION_NO_DOTS ubuntu1510
 ENV HOME /root


### PR DESCRIPTION
[IBM-Swift/kitura-ubuntu-docker](https://github.com/IBM-Swift/kitura-ubuntu-docker) builds were failing with the 2016-01-25 snapshot. Updating to 2016-02-08 fixes this issue.