### PR TITLE
Removed unneeded lines from apt-get to reduce size of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,11 @@ RUN apt-get update && apt-get install -y \
   libpython2.7 \
   libicu-dev \
   wget \
-  libcurl4-openssl-dev
+  libcurl4-openssl-dev \
+  vim
+
+ADD .vim /root/.vim
+ADD .vimrc /root/.vimrc
 
 RUN echo "set -o vi" >> /root/.bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,29 +33,13 @@ WORKDIR ${WORK_DIR}
 
 # Linux OS utils
 RUN apt-get update && apt-get install -y \
-  automake \
   build-essential \
   clang \
-  curl \
-  gcc-4.8 \
   git \
-  g++-4.8 \
-  libbsd-dev \
-  libglib2.0-dev \
   libpython2.7 \
   libicu-dev \
-  libtool \
-  lsb-core \
-  openssh-client \
-  vim \
   wget \
-  libcurl4-openssl-dev \
-  openssl \
-  libssl-dev \
-  uuid-dev
-
-ADD .vim /root/.vim
-ADD .vimrc /root/.vimrc
+  libcurl4-openssl-dev
 
 RUN echo "set -o vi" >> /root/.bashrc
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Docker image with the Swift 3.0 RELEASE binaries and dependencies for running Ki
 3. Reduced size of the Docker image.
 4. Updated Dockerfile per guidelines in [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).
 
+# Pull this image from Docker Hub
+You can execute the following command to download the latest version of this image from Docker Hub:
+
+```
+docker pull ibmcom/swift-ubuntu:latest
+```
+
+# Using this image for development
+You can mount a folder on your host to your Docker container using the following command:
+
+```
+docker run -i -t -v <absolute path to the swift package>:/root/<swift package name> ibmcom/swift-ubuntu:latest /bin/bash
+```
+
+After executing the above command, you will have terminal access to the Docker container.
+
 # Privilege mode
 If you attempt to run the Swift REPL and you get the error `failed to launch REPL process: process launch failed: 'A' packet returned an error: 8`, then you should run your Docker container in privilege mode:
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 Docker image with the Swift 3.0 RELEASE binaries and dependencies for running Kitura-based applications. Our development team uses this image for development and testing of Swift 3 applications on the Linux Ubuntu (v14.04) operating system.
 
 # Recent updates
-1. Upgraded Dockerfile to the Swift 3.0 RELEASE binaries.
-2. Aligned version of Ubuntu with version found in Cloud Foundry environments (14.04).
-3. Reduced size of the Docker image.
-4. Updated Dockerfile per guidelines in [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).
+1. Removed packages from Dockerfile no longer needed.
+2. Upgraded Dockerfile to the Swift 3.0 RELEASE binaries.
+3. Aligned version of Ubuntu with version found in Cloud Foundry environments (14.04).
+4. Reduced size of the Docker image.
+5. Updated Dockerfile per guidelines in [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).
 
 # Pull this image from Docker Hub
 You can execute the following command to download the latest version of this image from Docker Hub:


### PR DESCRIPTION
Tested his on Kitura-Starter-Bluemix and REPL.  Size of image is now 1.033 GB from 1.15 GB
