### PR TITLE
Update signing keys used by Swift.org

### DIFF
--- a/swift-development/Dockerfile
+++ b/swift-development/Dockerfile
@@ -58,6 +58,7 @@ RUN wget https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_D
       '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F' \
       'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
       '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
+      '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' \
   && gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys  \
   && gpg --verify $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && tar xzvf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz --strip-components=1 \

--- a/swift-runtime/Dockerfile
+++ b/swift-runtime/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
       '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F' \
       'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
       '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
+      '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' \
   && gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys  \
   && gpg --verify $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && tar xzvf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz $SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr/lib/swift/linux --strip-components=1 \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add latest `Swift Automatic Signing Key #2 <swift-infrastructure@swift.org>` signing key.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
master and development builds are now signed with this key. Without the update you cannot use the current Swift 4.1 snapshots.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with [master 2017-12-06-a](https://swift.org/builds/development/ubuntu1404/swift-DEVELOPMENT-SNAPSHOT-2017-12-06-a/swift-DEVELOPMENT-SNAPSHOT-2017-12-06-a-ubuntu14.04.tar.gz) and [development 2017-12-04-a](https://swift.org/builds/swift-4.1-branch/ubuntu1404/swift-4.1-DEVELOPMENT-SNAPSHOT-2017-12-04-a/swift-4.1-DEVELOPMENT-SNAPSHOT-2017-12-04-a-ubuntu14.04.tar.gz).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
