### PR TITLE
Swift 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 This repo contains the code for generating two Docker images for Swift:
 
-- The `ibmcom/swift-ubuntu` image contains the Swift 4.2.3 RELEASE toolchain as well as the dependencies for running Kitura-based applications. Our development team uses this image for development and testing of Swift 4 applications on the Linux Ubuntu (v14.04) operating system.
-- The `ibmcom/swift-ubuntu-runtime` image contains only those libraries (`.so` files) provided by the Swift 4.2.3 RELEASE toolchain that are required to run Swift applications. Note that this image does not contain SwiftPM or any of the build tools used when compiling and linking Swift applications. Hence, the size for the `ibmcom/swift-ubuntu-runtime` image (~300 MB) is much smaller than that of the `ibmcom/swift-ubuntu` image. The `ibmcom/swift-ubuntu-runtime` image is ideal for provisioning your Swift application as an [IBM Container](https://www.ibm.com/cloud-computing/bluemix/containers) on the IBM Cloud.
+- The `ibmcom/swift-ubuntu` image contains the Swift 5.0 RELEASE toolchain as well as the dependencies for running Kitura-based applications. Our development team uses this image for development and testing of Swift 4 applications on the Linux Ubuntu (v14.04) operating system.
+- The `ibmcom/swift-ubuntu-runtime` image contains only those libraries (`.so` files) provided by the Swift 5.0 RELEASE toolchain that are required to run Swift applications. Note that this image does not contain SwiftPM or any of the build tools used when compiling and linking Swift applications. Hence, the size for the `ibmcom/swift-ubuntu-runtime` image (~300 MB) is much smaller than that of the `ibmcom/swift-ubuntu` image. The `ibmcom/swift-ubuntu-runtime` image is ideal for provisioning your Swift application as an [IBM Container](https://www.ibm.com/cloud-computing/bluemix/containers) on the IBM Cloud.
 
 - The `ibmcom/swift-ubuntu-xenial` and `ibmcom/swift-ubuntu-xenial-runtime` images follow a similar convention, but for Linux Ubuntu 16.04. These images are multi-arch so will pull down the appropriate image for your architecture. We currently offer support for `amd64` and `s390x` architectures.
 
 # Recent updates
-1. Upgraded to the Swift 4.2.3 RELEASE binaries.
+1. Upgraded to the Swift 5.0 RELEASE binaries.
 2. Changed location of Swift binaries and libraries so they are available system wide (not just for the `root` user).
 3. Reduced number of layers in images.
 4. Removed system packages no longer needed.
@@ -53,17 +53,17 @@ docker pull ibmcom/swift-ubuntu:latest
 ```
 
 ### Use a specific version of ibmcom/swift-ubuntu
-Docker images are tagged with Swift version number. To use the Swift 4.2.3 image from Docker Hub, issue the following command:
+Docker images are tagged with Swift version number. To use the Swift 5.0 image from Docker Hub, issue the following command:
 
 ```
-docker pull ibmcom/swift-ubuntu:4.2.3
+docker pull ibmcom/swift-ubuntu:5.0
 ```
 
 ## Using ibmcom/swift-ubuntu for development
 Mount a folder on your host to your Docker container using the following command:
 
 ```
-docker run -i -t -v <absolute path to the swift package>:/<swift package name> ibmcom/swift-ubuntu:4.2.3
+docker run -i -t -v <absolute path to the swift package>:/<swift package name> ibmcom/swift-ubuntu:5.0
 ```
 
 After executing the above command, you will have terminal access to the Docker container (the default command for the image is `/bin/bash`). This will allow you to build, test, and run your Swift application in a Linux environment (Ubuntu v14.04).
@@ -72,7 +72,7 @@ After executing the above command, you will have terminal access to the Docker c
 If you attempt to run the Swift REPL and you get the error `failed to launch REPL process: process launch failed: 'A' packet returned an error: 8`, then you should run your Docker container in privileged mode:
 
 ```
-docker run --privileged -i -t ibmcom/swift-ubuntu:4.2.3
+docker run --privileged -i -t ibmcom/swift-ubuntu:5.0
 ```
 
 This issue is described at https://bugs.swift.org/browse/SR-54.
@@ -113,10 +113,10 @@ docker pull ibmcom/swift-ubuntu-runtime:latest
 ```
 
 ### Use a specific version of ibmcom/swift-ubuntu-runtime
-Docker images are now tagged with Swift version number. To use the Swift 4.2.3 image from Docker Hub, issue the following command:
+Docker images are now tagged with Swift version number. To use the Swift 5.0 image from Docker Hub, issue the following command:
 
 ```
-docker pull ibmcom/swift-ubuntu-runtime:4.2.3
+docker pull ibmcom/swift-ubuntu-runtime:5.0
 ```
 
 ## Using ibmcom/swift-ubuntu-runtime
@@ -127,7 +127,7 @@ You can extend the `ibmcom/swift-ubuntu-runtime` image in your own Dockerfile to
 
 ...
 
-FROM ibmcom/swift-ubuntu-runtime:4.2.3
+FROM ibmcom/swift-ubuntu-runtime:5.0
 LABEL Description="Docker image for running the Kitura-Starter sample application."
 
 USER root

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Build Status - Master](https://travis-ci.org/IBM-Swift/swift-ubuntu-docker.svg?branch=master)](https://travis-ci.org/IBM-Swift/swift-ubuntu-docker)
 
-# Swift 4 - Ubuntu Docker
+# Swift 5 - Ubuntu Docker
 
 This repo contains the code for generating two Docker images for Swift:
 
-- The `ibmcom/swift-ubuntu` image contains the Swift 5.0 RELEASE toolchain as well as the dependencies for running Kitura-based applications. Our development team uses this image for development and testing of Swift 4 applications on the Linux Ubuntu (v14.04) operating system.
+- The `ibmcom/swift-ubuntu` image contains the Swift 5.0 RELEASE toolchain as well as the dependencies for running Kitura-based applications. Our development team uses this image for development and testing of Swift 5 applications on the Linux Ubuntu (v14.04) operating system.
 - The `ibmcom/swift-ubuntu-runtime` image contains only those libraries (`.so` files) provided by the Swift 5.0 RELEASE toolchain that are required to run Swift applications. Note that this image does not contain SwiftPM or any of the build tools used when compiling and linking Swift applications. Hence, the size for the `ibmcom/swift-ubuntu-runtime` image (~300 MB) is much smaller than that of the `ibmcom/swift-ubuntu` image. The `ibmcom/swift-ubuntu-runtime` image is ideal for provisioning your Swift application as an [IBM Container](https://www.ibm.com/cloud-computing/bluemix/containers) on the IBM Cloud.
 
 - The `ibmcom/swift-ubuntu-xenial` and `ibmcom/swift-ubuntu-xenial-runtime` images follow a similar convention, but for Linux Ubuntu 16.04. These images are multi-arch so will pull down the appropriate image for your architecture. We currently offer support for `amd64` and `s390x` architectures.

--- a/ci/execute_script.sh
+++ b/ci/execute_script.sh
@@ -18,9 +18,9 @@
 set -ev
 
 # Swift version to use in Development Dockerfiles.
-DEVELOPMENT_VERSION="4.2.3"
+DEVELOPMENT_VERSION="5.0"
 # Swift version to use in Runtime Dockerfiles.
-RUNTIME_VERSION="4.2.3"
+RUNTIME_VERSION="5.0"
 
 # Manifest-tool used for pushing multi-arch docker images
 git clone https://github.com/estesp/manifest-tool.git --branch v0.9.0

--- a/swift-development/swift-ubuntu-trusty/Dockerfile
+++ b/swift-development/swift-ubuntu-trusty/Dockerfile
@@ -60,6 +60,7 @@ RUN wget https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_D
       'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
       '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
       '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' \
+      'A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561' \
   && gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys  \
   && gpg --verify $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && tar xzvf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz --strip-components=1 \

--- a/swift-development/swift-ubuntu-xenial-multiarch/amd64/Dockerfile
+++ b/swift-development/swift-ubuntu-xenial-multiarch/amd64/Dockerfile
@@ -63,6 +63,7 @@ RUN wget https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_D
       'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
       '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
       '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' \
+      'A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561' \
   && gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys  \
   && gpg --verify $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && tar xzvf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz --strip-components=1 \

--- a/swift-runtime/swift-ubuntu-trusty/Dockerfile
+++ b/swift-runtime/swift-ubuntu-trusty/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
       'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
       '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
       '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' \
+      'A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561' \
   && gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys  \
   && gpg --verify $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && tar xzvf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz $SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr/lib/swift/linux --strip-components=1 \

--- a/swift-runtime/swift-ubuntu-xenial-multiarch/amd64/Dockerfile
+++ b/swift-runtime/swift-ubuntu-xenial-multiarch/amd64/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
       'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6' \
       '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235' \
       '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' \
+      'A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561' \
   && gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys  \
   && gpg --verify $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && tar xzvf $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz $SWIFT_SNAPSHOT-$UBUNTU_VERSION/usr/lib/swift/linux --strip-components=1 \


### PR DESCRIPTION
These changes upgrade the [IBM Swift docker images](https://hub.docker.com/r/ibmcom/swift-ubuntu) to use [Swift 5.0](https://forums.swift.org/t/swift-5-released/22109).