### PR TITLE
Use --progress=dot:giga for quieter wget output

### DIFF
--- a/swift-development/swift-ubuntu-trusty/Dockerfile
+++ b/swift-development/swift-ubuntu-trusty/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
   && echo "set -o vi" >> /root/.bashrc
 
 # Install Swift compiler
-RUN wget https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz \
+RUN wget --progress=dot:giga https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz \
     https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && gpg --keyserver hkp://pool.sks-keyservers.net \
       --recv-keys \

--- a/swift-development/swift-ubuntu-xenial-multiarch/amd64/Dockerfile
+++ b/swift-development/swift-ubuntu-xenial-multiarch/amd64/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
   && echo "set -o vi" >> /root/.bashrc
 
 # Install Swift compiler
-RUN wget https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz \
+RUN wget --progress=dot:giga https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz \
     https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && gpg --keyserver hkp://pool.sks-keyservers.net \
       --recv-keys \

--- a/swift-runtime/swift-ubuntu-trusty/Dockerfile
+++ b/swift-runtime/swift-ubuntu-trusty/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
   libcurl4-openssl-dev \
   wget \
   && apt-get clean \
-  && wget -q https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz \
+  && wget --progress=dot:giga https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz \
      https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && gpg --keyserver hkp://pool.sks-keyservers.net \
       --recv-keys \

--- a/swift-runtime/swift-ubuntu-xenial-multiarch/amd64/Dockerfile
+++ b/swift-runtime/swift-ubuntu-xenial-multiarch/amd64/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y \
   libcurl4-openssl-dev \
   wget \
   && apt-get clean \
-  && wget -q https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz \
+  && wget --progress=dot:giga https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz \
      https://swift.org/builds/$SWIFT_SNAPSHOT_LOWERCASE/$UBUNTU_VERSION_NO_DOTS/$SWIFT_SNAPSHOT/$SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz.sig \
   && gpg --keyserver hkp://pool.sks-keyservers.net \
       --recv-keys \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In https://github.com/IBM-Swift/Package-Builder/pull/146 we introduced `--progress=dot:giga` which gives a nice balance of steady progress vs. compact output which seems to work well in a CI environment or otherwise.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the `wget` from swift.org is particularly slow when running through CI, there can be two undesirable outcomes:
- the build may be terminated due to lack of output (if it takes > 10 minutes to download a build, using `wget -q`), or
- the download process produces vast amounts of output (if running without `-q`) as very little progress is made per line.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
