### PR TITLE
Swift 5.0.2 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 This repo contains the code for generating two Docker images for Swift:
 
-- The `ibmcom/swift-ubuntu` image contains the Swift 5.0.1 RELEASE toolchain as well as the dependencies for running Kitura-based applications. Our development team uses this image for development and testing of Swift 5 applications on the Linux Ubuntu (v14.04) operating system.
-- The `ibmcom/swift-ubuntu-runtime` image contains only those libraries (`.so` files) provided by the Swift 5.0.1 RELEASE toolchain that are required to run Swift applications. Note that this image does not contain SwiftPM or any of the build tools used when compiling and linking Swift applications. Hence, the size for the `ibmcom/swift-ubuntu-runtime` image (~300 MB) is much smaller than that of the `ibmcom/swift-ubuntu` image. The `ibmcom/swift-ubuntu-runtime` image is ideal for provisioning your Swift application as an [IBM Container](https://www.ibm.com/cloud-computing/bluemix/containers) on the IBM Cloud.
+- The `ibmcom/swift-ubuntu` image contains the Swift 5.0.2 RELEASE toolchain as well as the dependencies for running Kitura-based applications. Our development team uses this image for development and testing of Swift 5 applications on the Linux Ubuntu (v14.04) operating system.
+- The `ibmcom/swift-ubuntu-runtime` image contains only those libraries (`.so` files) provided by the Swift 5.0.2 RELEASE toolchain that are required to run Swift applications. Note that this image does not contain SwiftPM or any of the build tools used when compiling and linking Swift applications. Hence, the size for the `ibmcom/swift-ubuntu-runtime` image (~300 MB) is much smaller than that of the `ibmcom/swift-ubuntu` image. The `ibmcom/swift-ubuntu-runtime` image is ideal for provisioning your Swift application as an [IBM Container](https://www.ibm.com/cloud-computing/bluemix/containers) on the IBM Cloud.
 
 - The `ibmcom/swift-ubuntu-xenial` and `ibmcom/swift-ubuntu-xenial-runtime` images follow a similar convention, but for Linux Ubuntu 16.04. These images are multi-arch so will pull down the appropriate image for your architecture. We currently offer support for `amd64` and `s390x` architectures.
 
 # Recent updates
-1. Upgraded to the Swift 5.0.1 RELEASE binaries.
+1. Upgraded to the Swift 5.0.2 RELEASE binaries.
 2. Changed location of Swift binaries and libraries so they are available system wide (not just for the `root` user).
 3. Reduced number of layers in images.
 4. Removed system packages no longer needed.
@@ -53,17 +53,17 @@ docker pull ibmcom/swift-ubuntu:latest
 ```
 
 ### Use a specific version of ibmcom/swift-ubuntu
-Docker images are tagged with Swift version number. To use the Swift 5.0.1 image from Docker Hub, issue the following command:
+Docker images are tagged with Swift version number. To use the Swift 5.0.2 image from Docker Hub, issue the following command:
 
 ```
-docker pull ibmcom/swift-ubuntu:5.0.1
+docker pull ibmcom/swift-ubuntu:5.0.2
 ```
 
 ## Using ibmcom/swift-ubuntu for development
 Mount a folder on your host to your Docker container using the following command:
 
 ```
-docker run -i -t -v <absolute path to the swift package>:/<swift package name> ibmcom/swift-ubuntu:5.0.1
+docker run -i -t -v <absolute path to the swift package>:/<swift package name> ibmcom/swift-ubuntu:5.0.2
 ```
 
 After executing the above command, you will have terminal access to the Docker container (the default command for the image is `/bin/bash`). This will allow you to build, test, and run your Swift application in a Linux environment (Ubuntu v14.04).
@@ -72,7 +72,7 @@ After executing the above command, you will have terminal access to the Docker c
 If you attempt to run the Swift REPL and you get the error `failed to launch REPL process: process launch failed: 'A' packet returned an error: 8`, then you should run your Docker container in privileged mode:
 
 ```
-docker run --privileged -i -t ibmcom/swift-ubuntu:5.0.1
+docker run --privileged -i -t ibmcom/swift-ubuntu:5.0.2
 ```
 
 This issue is described at https://bugs.swift.org/browse/SR-54.
@@ -113,10 +113,10 @@ docker pull ibmcom/swift-ubuntu-runtime:latest
 ```
 
 ### Use a specific version of ibmcom/swift-ubuntu-runtime
-Docker images are now tagged with Swift version number. To use the Swift 5.0.1 image from Docker Hub, issue the following command:
+Docker images are now tagged with Swift version number. To use the Swift 5.0.2 image from Docker Hub, issue the following command:
 
 ```
-docker pull ibmcom/swift-ubuntu-runtime:5.0.1
+docker pull ibmcom/swift-ubuntu-runtime:5.0.2
 ```
 
 ## Using ibmcom/swift-ubuntu-runtime
@@ -127,7 +127,7 @@ You can extend the `ibmcom/swift-ubuntu-runtime` image in your own Dockerfile to
 
 ...
 
-FROM ibmcom/swift-ubuntu-runtime:5.0.1
+FROM ibmcom/swift-ubuntu-runtime:5.0.2
 LABEL Description="Docker image for running the Kitura-Starter sample application."
 
 USER root

--- a/ci/execute_script.sh
+++ b/ci/execute_script.sh
@@ -18,9 +18,9 @@
 set -ev
 
 # Swift version to use in Development Dockerfiles.
-DEVELOPMENT_VERSION="5.0.1"
+DEVELOPMENT_VERSION="5.0.2"
 # Swift version to use in Runtime Dockerfiles.
-RUNTIME_VERSION="5.0.1"
+RUNTIME_VERSION="5.0.2"
 
 # Manifest-tool used for pushing multi-arch docker images
 git clone https://github.com/estesp/manifest-tool.git --branch v0.9.0


### PR DESCRIPTION
[Swift 5.0.2](https://forums.swift.org/t/swift-5-0-2/27008) was released earlier today.  This PR upgrades the official IBM Swift Docker `latest` images and tags them with the `5.0.2` tag.